### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/zxenonx/fastapi-promo-tasks/security/code-scanning/1](https://github.com/zxenonx/fastapi-promo-tasks/security/code-scanning/1)

To fix the detected error, add a `permissions` key at the root of the workflow file to restrict the GITHUB_TOKEN's permissions. The minimal permissions required for this workflow are `contents: read`, because the workflow is reading repository contents (e.g., Python files) to analyze them with pylint. No write permissions are needed.

The fix involves editing the `.github/workflows/pylint.yml` file to add:
- A `permissions` block at the root level of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
